### PR TITLE
Expose hljs for external modification

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,7 +371,7 @@ const procOpts = (opts = {}) => {
 	return options
 }
 
-const chromafi = (value, opts) => {
+let chromafi = (value, opts) => {
 	opts = procOpts(opts)
 
 	if (typeof value === 'function') {
@@ -397,5 +397,7 @@ const chromafi = (value, opts) => {
 
 	throw new Error('🦅  Chromafi: You must pass a function, string or object.')
 }
+
+chromafi.hljs = hljs; //expose hljs for modification
 
 module.exports = chromafi

--- a/index.js
+++ b/index.js
@@ -371,7 +371,7 @@ const procOpts = (opts = {}) => {
 	return options
 }
 
-let chromafi = (value, opts) => {
+const chromafi = (value, opts) => {
 	opts = procOpts(opts)
 
 	if (typeof value === 'function') {
@@ -398,6 +398,6 @@ let chromafi = (value, opts) => {
 	throw new Error('🦅  Chromafi: You must pass a function, string or object.')
 }
 
-chromafi.hljs = hljs; //expose hljs for modification
+chromafi.hljs = hljs // Expose hljs for modification
 
 module.exports = chromafi


### PR DESCRIPTION
This pull request is intended to address issue #8 that I opened recently.  Apologies if this is not how you'd prefer to solve the problem, but this is the way that I'm currently using in my forked copy.

This PR adds a visible `hljs` member to the `chromafi` object; `chromafi` is no longer just a function, now it's an object with an `hljs` member.  By modifying this member, one can use `chromafi` with languages other than the ones it natively supports.  For instance, here's an example from my own code, using the `highlightjs-solidity` package:

```
var chromafi = require("chromafi");
var hljsDefineSolidity = require("highlightjs-solidity");
hljsDefineSolidity(chromafi.hljs);
```

Now `chromafi` will be able to colorize Solidity.  I then use this later:

```
    let options = {
      lang: "solidity",
      lineNumbers: false,
      stripIndent: false,
      codePad: 0
    };
    return chromafi(code, options);
```

And, tada, we've used `chromafi` to colorize Solidity despite it not being natively supported!  And this could just as well be used with any number of other languages that are not part of the `hljs` base package but have had external highlightjs language definitions written for them.

Again, if you'd prefer to solve this some other way, I understand, but I thought I should at least PR my own solution to this problem.  Thank you!